### PR TITLE
Fix a misleading sentense

### DIFF
--- a/src/ru/api/refs-api.md
+++ b/src/ru/api/refs-api.md
@@ -16,7 +16,7 @@ count.value++
 console.log(count.value) // 1
 ```
 
-Если свойству value ref-ссылки передается объект, то объект становится глубоко реактивным с помощью метода [reactive](basic-reactivity.md#reactive).
+Если свойству value ref-ссылки передаётся объект, то объект становится глубоко реактивным с помощью метода [reactive](basic-reactivity.md#reactive).
 
 **Типизация:**
 

--- a/src/ru/api/refs-api.md
+++ b/src/ru/api/refs-api.md
@@ -16,7 +16,7 @@ count.value++
 console.log(count.value) // 1
 ```
 
-Если в объект присваивается значение реактивной ref-ссылки, то объект становится глубоко реактивным с помощью метода [reactive](basic-reactivity.md#reactive).
+Если свойству value ref-ссылки передается объект, то объект становится глубоко реактивным с помощью метода [reactive](basic-reactivity.md#reactive).
 
 **Типизация:**
 


### PR DESCRIPTION
Предложение:
  Если в объект присваивается значение реактивной ref-ссылки
Заменено на другое предложение:
  Если свойству value ref-ссылки передается объект,

## Description of Problem

## Proposed Solution

## Additional Information
